### PR TITLE
Solve HOTFIX Simplifica a definição BorderRadius do widget Button

### DIFF
--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -27,12 +27,7 @@ class Button extends StatelessWidget {
       minWidth: double.infinity,
       height: 66,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.only(
-          topRight: Radius.circular(4.0),
-          topLeft: Radius.circular(4.0),
-          bottomRight: Radius.circular(4.0),
-          bottomLeft: Radius.circular(4.0),
-        ),
+        borderRadius: BorderRadius.circular(4.0),
       ),
     );
   }


### PR DESCRIPTION
## Descrição

Mudança na definição do BorderRadius do Button, de: `BorderRadius.only`, para `BorderRadius.circular` já que o raio é igual para todos os cantos.

## Tipos de mudança

Quais mudanças seu código introduz ao projeto?

- [ ] Bugfix 
- [x] Criação/Evolução de funcionalidade  
- [ ] Atualização de Documentação 

## Checklist
- [x] Lint e testes passaram localmente com minhas mudanças
- [ ] Eu adicionei testes que provam que minha correção é eficaz ou que minha feature funciona
- [ ] Adicionei informações necessárias na documentação (se precisar)
